### PR TITLE
Spin up the ecs agent after user_data has run

### DIFF
--- a/ecs-agent-ubuntu-16.04.json
+++ b/ecs-agent-ubuntu-16.04.json
@@ -58,10 +58,9 @@
       "destination": "/etc/ecs/ecs.config"
     },
     {
-      "type": "shell",
-      "inline": [
-        "sudo docker create --name ecs-agent --restart=always --volume=/var/run:/var/run --volume=/var/log/ecs/:/log --volume=/var/lib/ecs/data:/data --volume=/etc/ecs:/etc/ecs --net=host --env-file=/etc/ecs/ecs.config  amazon/amazon-ecs-agent:latest"
-      ]
+      "type": "file",
+      "source": "ecs-files/80.init-ecs.cfg",
+      "destination": "/etc/cloud/cloud.cfg.d/80.init-ecs.cfg"
     }
   ]
 }

--- a/ecs-files/80.init-ecs.cfg
+++ b/ecs-files/80.init-ecs.cfg
@@ -1,0 +1,2 @@
+bootcmd:
+  - "docker run --name ecs-agent --detach --restart=always --volume=/var/run:/var/run --volume=/var/log/ecs/:/log --volume=/var/lib/ecs/data:/data --volume=/etc/ecs:/etc/ecs --net=host --env-file=/etc/ecs/ecs.config  amazon/amazon-ecs-agent:latest"


### PR DESCRIPTION
If I've got this right, this will hook into the cloud-init configuration
itself. As far as I can tell, runcmd instructions run late in the
instance initialisation stage, so we can configure user_data before we
try to spin up the agent.

See the following pages on the cloud-init documentation:

 * https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd
 * https://cloudinit.readthedocs.io/en/latest/topics/boot.html