### PR TITLE
Don't create the ecs instance container at all

### DIFF
--- a/ecs-agent-ubuntu-16.04.json
+++ b/ecs-agent-ubuntu-16.04.json
@@ -58,9 +58,10 @@
       "destination": "/etc/ecs/ecs.config"
     },
     {
-      "type": "file",
-      "source": "ecs-files/80.init-ecs.cfg",
-      "destination": "/etc/cloud/cloud.cfg.d/80.init-ecs.cfg"
+      "type": "shell",
+      "inline": [
+        "sudo chmod 0755 /etc/ecs"
+      ]
     }
   ]
 }

--- a/ecs-files/80.init-ecs.cfg
+++ b/ecs-files/80.init-ecs.cfg
@@ -1,2 +1,0 @@
-bootcmd:
-  - "docker run --name ecs-agent --detach --restart=always --volume=/var/run:/var/run --volume=/var/log/ecs/:/log --volume=/var/lib/ecs/data:/data --volume=/etc/ecs:/etc/ecs --net=host --env-file=/etc/ecs/ecs.config  amazon/amazon-ecs-agent:latest"


### PR DESCRIPTION
We'll do this in the user_data script instead in terraform. This is
because cloud-init doesn't seem to want to play ball with doing it at
the right time and in the right order.